### PR TITLE
Fix variable names in ImageScanSummaryAssessmentGate script

### DIFF
--- a/scripts/ImageScanSummaryAssessmentGate.ps1
+++ b/scripts/ImageScanSummaryAssessmentGate.ps1
@@ -109,7 +109,7 @@ $query = "securityresources
  | extend IsScanned = iif(findingsCountOverAll > 0, true, false)"
  
 # Add filter to get scan summary for specific provided image
-$filter = "| where imageDigest =~ '$imagedigest' and repository =~ '$repository' and registryResourceName =~ '$registryname'" 
+$filter = "| where imageDigest =~ '$imageDigest' and repository =~ '$repository' and registryResourceName =~ '$registryName'"
 $query  = @($query, $filter) | out-string 
 
 Write-Host "Query: $query"


### PR DESCRIPTION
## Summary
- fix case-sensitivity bug in ImageScanSummaryAssessmentGate.ps1

## Testing
- `grep -n imagedigest scripts/ImageScanSummaryAssessmentGate.ps1`


------
https://chatgpt.com/codex/tasks/task_e_683f43ba95448328ae9b246cea6198b1