### PR TITLE
Fix registry variable in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,4 +88,5 @@ stages:
         sudo chmod 400 $(sshKey.secureFilePath)
         ssh -o StrictHostKeyChecking=no -i $(sshKey.secureFilePath) ubuntu@35.180.100.164 "
           docker ps -aq | xargs docker stop | xargs docker rm &&
-          docker run -d -p 8080:80 $(IMAGE_REPOSITORY)/$(IMAGE_REPOSITORY):$(TAG)"
+          docker run -d -p 8080:80 $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY):$(TAG)"
+


### PR DESCRIPTION
## Summary
- fix docker run command to use IMAGE_REGISTRY with IMAGE_REPOSITORY

## Testing
- `terraform validate` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f9061a20c8328838541b880b2002a